### PR TITLE
 Add git to builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,7 @@ ENV HOME /home/jenkins
 RUN addgroup -S -g 10000 jenkins
 RUN adduser -S -u 10000 -h $HOME -G jenkins jenkins
 
+RUN apt-get install git
+
 WORKDIR /home/jenkins
 USER jenkins


### PR DESCRIPTION
The builder needs to have git installed for yarn or npm to fetch from git or bitbucket.